### PR TITLE
[fixes #7] Optionally set unicode literals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
     # - NODE_VERSION="4.0"
 python:
     - "nightly"
+    - "3.6"
     - "3.5"
     - "3.4"
     - "3.3"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,8 @@ environment:
     - PYTHON: "C:\\Python34-x64"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python36-x64"
 
     - nodejs_version: "7"
     - nodejs_version: "6"

--- a/node_python_bridge.py
+++ b/node_python_bridge.py
@@ -11,6 +11,13 @@ import struct
 NODE_CHANNEL_FD = int(os.environ['NODE_CHANNEL_FD'])
 UNICODE_TYPE = unicode if sys.version_info[0] == 2 else str
 
+if sys.version_info[0] <= 2:
+    # print('PY2')
+    def _exec(_code_, _globs_):
+        exec('exec _code_ in _globs_')
+else:
+    _exec = getattr(__builtins__, 'exec')
+
 _locals = {'__name__': '__console__', '__doc__': None}
 _compile = Compile()
 
@@ -81,7 +88,7 @@ if __name__ == '__main__':
 
             # Run Python code
             if data['type'] == 'execute':
-                exec _compile(data['code'], '<input>', 'exec') in _locals
+                _exec(_compile(data['code'], '<input>', 'exec'), _locals)
                 response = dict(type='success')
             else:
                 value = eval(_compile(data['code'], '<input>', 'eval'), _locals)

--- a/node_python_bridge.py
+++ b/node_python_bridge.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+from codeop import Compile
 import os
 import sys
 import json
@@ -9,6 +10,9 @@ import struct
 
 NODE_CHANNEL_FD = int(os.environ['NODE_CHANNEL_FD'])
 UNICODE_TYPE = unicode if sys.version_info[0] == 2 else str
+
+_locals = {'__name__': '__console__', '__doc__': None}
+_compile = Compile()
 
 
 if platform.system() == 'Windows':
@@ -77,10 +81,11 @@ if __name__ == '__main__':
 
             # Run Python code
             if data['type'] == 'execute':
-                exec(data['code'])
+                exec _compile(data['code'], '<input>', 'exec') in _locals
                 response = dict(type='success')
             else:
-                response = dict(type='success', value=eval(data['code']))
+                value = eval(_compile(data['code'], '<input>', 'eval'), _locals)
+                response = dict(type='success', value=value)
         except:
             t, e, tb = sys.exc_info()
             response = dict(type='exception', value=format_exception(t, e, tb))

--- a/test.js
+++ b/test.js
@@ -13,10 +13,10 @@ test('leave __future__ alone!', t => {
 
     let python = pythonBridge();
     python.ex`import sys`;
-    python`sys.version_info.major > 2`.then(unicode_strings => {
+    python`sys.version_info[0] > 2`.then(py3 => {
         python`type('').__name__`.then(x => t.equal(x, 'str'));
         python.ex`from __future__ import unicode_literals`;
-        if (unicode_strings) {
+        if (py3) {
             python`type('').__name__`.then(x => t.equal(x, 'str'));
         } else {
             python`type('').__name__`.then(x => t.equal(x, 'unicode'));

--- a/test.js
+++ b/test.js
@@ -238,3 +238,21 @@ test('json interpolation', t => {
     t.equal(pythonBridge.json`hello(${'world'}, ${[1, 2, 3]})`, 'hello("world", [1,2,3])');
     t.end();
 });
+
+
+test('leave __future__ alone!', t => {
+    t.plan(2);
+
+    let python = pythonBridge();
+    python`sys.version_info.major <= 2`.then(byte_strings => {
+        if (!byte_strings) {
+            return;
+        }
+        python`type('').__name__`.then(x => t.equal(x, 'str'));
+        python.ex`from __future__ import unicode_literals`;
+        python`type('').__name__`.then(x => t.equal(x, 'unicode'));
+
+    }).finally(() => {
+        python.end();
+    });
+});

--- a/test.js
+++ b/test.js
@@ -13,13 +13,14 @@ test('leave __future__ alone!', t => {
 
     let python = pythonBridge();
     python.ex`import sys`;
-    python`sys.version_info.major <= 2`.then(byte_strings => {
-        if (!byte_strings) {
-            return;
-        }
+    python`sys.version_info.major > 2`.then(unicode_strings => {
         python`type('').__name__`.then(x => t.equal(x, 'str'));
         python.ex`from __future__ import unicode_literals`;
-        python`type('').__name__`.then(x => t.equal(x, 'unicode'));
+        if (unicode_strings) {
+            python`type('').__name__`.then(x => t.equal(x, 'str'));
+        } else {
+            python`type('').__name__`.then(x => t.equal(x, 'unicode'));
+        }
     }).finally(() => {
         python.end();
     });

--- a/test.js
+++ b/test.js
@@ -8,6 +8,23 @@ let Promise = require('bluebird');
 let mkdirTemp = Promise.promisify(require('temp').mkdir);
 let path = require('path');
 
+test('leave __future__ alone!', t => {
+    t.plan(2);
+
+    let python = pythonBridge();
+    python.ex`import sys`;
+    python`sys.version_info.major <= 2`.then(byte_strings => {
+        if (!byte_strings) {
+            return;
+        }
+        python`type('').__name__`.then(x => t.equal(x, 'str'));
+        python.ex`from __future__ import unicode_literals`;
+        python`type('').__name__`.then(x => t.equal(x, 'unicode'));
+    }).finally(() => {
+        python.end();
+    });
+});
+
 test('readme', t => {
     t.test('example', t => {
         t.plan(2);
@@ -237,22 +254,4 @@ test('json interpolation', t => {
     t.equal(pythonBridge.json`hello(${'world'})`, 'hello("world")');
     t.equal(pythonBridge.json`hello(${'world'}, ${[1, 2, 3]})`, 'hello("world", [1,2,3])');
     t.end();
-});
-
-
-test('leave __future__ alone!', t => {
-    t.plan(2);
-
-    let python = pythonBridge();
-    python`sys.version_info.major <= 2`.then(byte_strings => {
-        if (!byte_strings) {
-            return;
-        }
-        python`type('').__name__`.then(x => t.equal(x, 'str'));
-        python.ex`from __future__ import unicode_literals`;
-        python`type('').__name__`.then(x => t.equal(x, 'unicode'));
-
-    }).finally(() => {
-        python.end();
-    });
 });


### PR DESCRIPTION
Keep `locals()` separate from the python bridge script.  Also keep track of compiler flags!  That way `from __future__ import unicode_literals` can change the compiler to interpret unicode strings.