### PR TITLE
Allow setting detached

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ function pythonBridge(opts) {
         env: opts && opts.env,
         uid: opts && opts.uid,
         gid: opts && opts.gid,
+        detached: opts && opts.detached,
         stdio: stdio.concat(['ipc'])
     };
 


### PR DESCRIPTION
Allow setting detached: true on the child process so that we can prevent it from propagating signals from parent