### PR TITLE
Support detached flag on Windows

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,6 +11,7 @@ export interface PythonBridgeOptions {
   env?: { [key: string]: string | undefined; };
   uid?: number;
   gid?: number;
+  detached?: boolean;
 }
 
 export interface PythonBridge {

--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ function pythonBridge(opts) {
         env: opts && opts.env,
         uid: opts && opts.uid,
         gid: opts && opts.gid,
-        stdio: stdio.concat(['ipc'])
+        stdio: stdio.concat(['ipc']),
+        detached: opts && opts.detached
     };
 
     // create process bridge


### PR DESCRIPTION
Without setting detached to `true` a console window is launched.

See https://github.com/innoverio/vscode-dbt-power-user/issues/179

I have opted to expose this config through the spawn options.